### PR TITLE
Fix overlay freeze and audio playback stability

### DIFF
--- a/AppSetup.cs
+++ b/AppSetup.cs
@@ -36,17 +36,16 @@ namespace MemeMic
         }
         public void CreateSettingsFile(string path = "", string overlayButton = "", string speakerVolume = "0.3",string screenNumber = "0")
         {
-            TextWriter writer = new StreamWriter(settingsFilePath);
-            writer.WriteLine(path + "," + overlayButton + "," + speakerVolume + "," + screenNumber);
-            writer.Close();
+            // One value per line so a comma in the meme folder path (or a locale-formatted number) can't corrupt the file.
+            File.WriteAllLines(settingsFilePath, new[] { path, overlayButton, speakerVolume, screenNumber });
         }
         public string ReadSettingsFile(byte lineNumber)
         {
-            TextReader reader = new StreamReader(settingsFilePath);
-            string settingsLine = reader.ReadLine();
-            reader.Close();
-            string[] separatedLines = settingsLine.Split(',');
-            return separatedLines[lineNumber];
+            string[] lines = File.ReadAllLines(settingsFilePath);
+            // Migrate the legacy single comma-joined line to the per-line format.
+            if (lines.Length == 1 && lines[0].Contains(","))
+                lines = lines[0].Split(',');
+            return lineNumber < lines.Length ? lines[lineNumber] : "";
         }
         public void ModifyFolderPath(string newPath)
         {
@@ -59,7 +58,9 @@ namespace MemeMic
         }
         public void FilterMemeFiles()
         {
-            string supportedExtensions = "*.mp3,*.aac,*.wav,*.webm,*.m4a,*.mp4,*.mkv,*.mpeg,*.flv";
+            var supportedExtensions = new HashSet<string>
+            { ".mp3", ".aac", ".wav", ".webm", ".m4a", ".mp4", ".mkv", ".mpeg", ".flv" };
+            filteredMemeFiles.Clear();   // don't accumulate duplicates if the user presses Start more than once
             string[] memeFiles = Directory.GetFiles(ReadSettingsFile(pathLine));
             foreach (string supportedMemeFile in memeFiles.Where(s => supportedExtensions.Contains(Path.GetExtension(s).ToLower())))
             {

--- a/EventListener.cs
+++ b/EventListener.cs
@@ -1,4 +1,5 @@
-﻿using System.Windows.Threading;
+using System;
+using System.Windows.Threading;
 using System.Windows.Controls;
 using EventHook;
 
@@ -41,7 +42,7 @@ namespace MemeMic
         {
             eventHookFactory = new EventHookFactory();
             overlay = new OverlayWindow();
-            micPlayer = new MicPlayer(playingOverlay);
+            micPlayer = new MicPlayer(OnPlaybackFinished);
             speakerPlayer = new SpeakerPlayer();
         }
 
@@ -74,8 +75,10 @@ namespace MemeMic
             keyboardWatcher.Start();
             keyboardWatcher.OnKeyInput += (s, e) =>
             {
+                // Hook callbacks run on a background thread; do only the cheap match here,
+                // then hand the actual work to the UI thread (which also serializes it).
                 if(e.KeyData.Keyname.ToString().Equals(savedButton) && e.KeyData.EventType.ToString().Equals("down"))
-                    ChangeOverlayState();
+                    Dispatcher.BeginInvoke(new Action(ChangeOverlayState));
             };
         }
 
@@ -93,21 +96,17 @@ namespace MemeMic
             {
                 string mouseInputName = e.Message.ToString();
                 string mouseInputData = e.MouseData.ToString();
-                if(overlayState.Equals("Shown"))
-                {
-                    if (mouseInputData.Equals(mouseWheelDownData))
-                        ScrollDown();
-                    else if (mouseInputData.Equals(mouseWheelUpData))
-                        ScrollUp();
-                }
 
-                if (savedButton.Contains("XButton"))
-                {
-                    if (mouseInputData.Equals(correctMouseData) && mouseInputName.Contains("DOWN"))
-                        ChangeOverlayState();
-                }
-                else if(mouseInputName.Equals(correctMouseButton))
-                        ChangeOverlayState();
+                if (mouseInputData.Equals(mouseWheelDownData))
+                    Dispatcher.BeginInvoke(new Action(ScrollDown));
+                else if (mouseInputData.Equals(mouseWheelUpData))
+                    Dispatcher.BeginInvoke(new Action(ScrollUp));
+
+                bool triggerPressed = savedButton.Contains("XButton")
+                    ? (mouseInputData.Equals(correctMouseData) && mouseInputName.Contains("DOWN"))
+                    : mouseInputName.Equals(correctMouseButton);
+                if (triggerPressed)
+                    Dispatcher.BeginInvoke(new Action(ChangeOverlayState));
             };
         }
 
@@ -128,62 +127,71 @@ namespace MemeMic
             }
         }
 
+        // Everything below runs on the UI thread (marshalled from the hook callbacks),
+        // so state transitions can't interleave and it is safe to touch the windows directly.
         private void ChangeOverlayState()
         {
             switch (overlayState)
             {
                 case "Hidden":
-                    Dispatcher.Invoke(() => { 
-                        overlay.Show();
-                        overlay.HighlightText(0);
-                    });
-                    overlayState = "Shown";
+                    overlay.Show();
+                    overlay.HighlightText(0);
                     memeIndex = 0;
+                    overlayState = "Shown";
                     break;
                 case "Shown":
+                    overlay.UnhighlightText(memeIndex);
+                    overlay.Hide();
+                    playingOverlay.Show();
                     micPlayer.play(AppSetup.GetInstance().filteredMemeFiles[memeIndex]);
                     speakerPlayer.Play(AppSetup.GetInstance().filteredMemeFiles[memeIndex]);
-                    Dispatcher.Invoke(() => {
-                        overlay.UnhighlightText(memeIndex);
-                        overlay.Hide();
-                        playingOverlay.Show();
-                    });
                     overlayState = "Playing";
                     break;
                 case "Playing":
                     micPlayer.stop();
                     speakerPlayer.Stop();
-                    Dispatcher.Invoke(() => {
-                        playingOverlay.Hide();
-                    });
+                    playingOverlay.Hide();
                     overlayState = "Hidden";
                     break;
             }
         }
 
+        // Called (via MicPlayer) when a clip stops, including reaching its own end.
+        private void OnPlaybackFinished()
+        {
+            if (!Dispatcher.CheckAccess())
+            {
+                Dispatcher.BeginInvoke(new Action(OnPlaybackFinished));
+                return;
+            }
+            if (overlayState.Equals("Playing"))
+            {
+                playingOverlay.Hide();
+                overlayState = "Hidden";
+            }
+        }
+
         private void ScrollDown()
         {
+            if (!overlayState.Equals("Shown"))
+                return;
             if (memeIndex != (AppSetup.GetInstance().filteredMemeFiles.Count - 1))
             {
                 memeIndex++;
-                Dispatcher.Invoke(() =>
-                {
-                    overlay.UnhighlightText(memeIndex - 1);
-                    overlay.HighlightText(memeIndex);
-                });
+                overlay.UnhighlightText(memeIndex - 1);
+                overlay.HighlightText(memeIndex);
             }
         }
 
         private void ScrollUp()
         {
+            if (!overlayState.Equals("Shown"))
+                return;
             if (memeIndex != 0)
             {
                 memeIndex--;
-                Dispatcher.Invoke(() =>
-                {
-                    overlay.UnhighlightText(memeIndex + 1);
-                    overlay.HighlightText(memeIndex);
-                });
+                overlay.UnhighlightText(memeIndex + 1);
+                overlay.HighlightText(memeIndex);
             }
         }
 

--- a/MicPlayer.cs
+++ b/MicPlayer.cs
@@ -1,39 +1,38 @@
-﻿using NAudio.Wave;
+using NAudio.Wave;
 using System;
-using System.Threading;
-using System.Windows;
 
 namespace MemeMic
 {
     class MicPlayer
     {
-        WaveOutEvent micPlayer = new WaveOutEvent();
-        PlayingOverlay playingOverlay;
+        readonly WaveOutEvent micPlayer = new WaveOutEvent();
+        MediaFoundationReader reader;
+        readonly Action onStopped;
 
-        public MicPlayer(PlayingOverlay playingOverlay)
+        public MicPlayer(Action onStopped)
         {
+            this.onStopped = onStopped;
             micPlayer.DeviceNumber = AppSetup.GetInstance().GetVirtualSpeakerNumber();
-            micPlayer.PlaybackStopped += Player_PlaybackStopped;
-            this.playingOverlay = playingOverlay;
+            micPlayer.PlaybackStopped += OnPlaybackStopped;
         }
 
         public void play(string path)
         {
-            MediaFoundationReader reader = new MediaFoundationReader(path);
-            micPlayer.Init(reader); 
+            reader = new MediaFoundationReader(path);
+            micPlayer.Init(reader);   // must run on the UI thread so PlaybackStopped comes back on it
             micPlayer.Play();
         }
 
-        private void Player_PlaybackStopped(object sender, StoppedEventArgs e)
-        {                                                       // It only needs to be added either in this class or
-            Application.Current.Dispatcher.Invoke(() => {       // SpeakerPlayer class and same goes for the playingOverlay
-                playingOverlay.Hide();
-            });
+        private void OnPlaybackStopped(object sender, StoppedEventArgs e)
+        {
+            reader?.Dispose();        // release the file here, after playback has fully stopped
+            reader = null;
+            onStopped?.Invoke();
         }
 
         public void stop()
         {
-            micPlayer.Dispose();
+            micPlayer.Stop();         // reader is disposed in OnPlaybackStopped; device is reused, never disposed
         }
     }
 }

--- a/OptionsWindow.xaml.cs
+++ b/OptionsWindow.xaml.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Diagnostics;
+using System.Globalization;
 using System.Windows;
 using System.Windows.Forms;
 using System.Windows.Input;
@@ -30,7 +31,8 @@ namespace MemeMic
         {
             ShowOverlayTextBox.Text = AppSetup.GetInstance().ReadSettingsFile(AppSetup.overlayButtonLine);
             PlayMemeTextBox.Text = AppSetup.GetInstance().ReadSettingsFile(AppSetup.overlayButtonLine);
-            double speakerVolume = 100*double.Parse(AppSetup.GetInstance().ReadSettingsFile(AppSetup.speakerVolumeLine));
+            double speakerVolume = 100*double.Parse(AppSetup.GetInstance().ReadSettingsFile(AppSetup.speakerVolumeLine),
+                CultureInfo.InvariantCulture);
             volumeTextBlock.Text = speakerVolume.ToString();
             volumeSlider.Value = speakerVolume;
         }
@@ -75,7 +77,8 @@ namespace MemeMic
                     MessageBoxIcon.Error);
             }
             else
-                AppSetup.GetInstance().ModifyOptions(ShowOverlayTextBox.Text,Convert.ToString(volumeSlider.Value/100),
+                AppSetup.GetInstance().ModifyOptions(ShowOverlayTextBox.Text,
+                    (volumeSlider.Value/100).ToString(CultureInfo.InvariantCulture),
                     screenComboBox.SelectedIndex.ToString());
         }
 

--- a/SpeakerPlayer.cs
+++ b/SpeakerPlayer.cs
@@ -1,29 +1,29 @@
-﻿using NAudio.Wave;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+using NAudio.Wave;
+using System.Globalization;
 
 namespace MemeMic
 {
     class SpeakerPlayer
     {
-        WaveOutEvent speakerPlayer = new WaveOutEvent();
+        readonly WaveOutEvent speakerPlayer = new WaveOutEvent();
+        MediaFoundationReader reader;
+
         public SpeakerPlayer()
         {                                                          //max volume = 1.0F
-            speakerPlayer.Volume = float.Parse(AppSetup.GetInstance().ReadSettingsFile(AppSetup.speakerVolumeLine));
+            speakerPlayer.Volume = float.Parse(AppSetup.GetInstance().ReadSettingsFile(AppSetup.speakerVolumeLine),
+                CultureInfo.InvariantCulture);                     // stored with '.'; parse culture-independently
             speakerPlayer.DeviceNumber = 0;                        // -1 or 0 mean the default playback device
+            speakerPlayer.PlaybackStopped += (s, e) => { reader?.Dispose(); reader = null; };
         }
         public void Play(string path)
         {
-            MediaFoundationReader reader = new MediaFoundationReader(path);
+            reader = new MediaFoundationReader(path);
             speakerPlayer.Init(reader);
             speakerPlayer.Play();
         }
         public void Stop()
         {
-            speakerPlayer.Dispose();
+            speakerPlayer.Stop();     // reader disposed in PlaybackStopped; device is reused, never disposed
         }
     }
 }


### PR DESCRIPTION
## What this fixes

The overlay would sometimes freeze when selecting a sound — occasionally
hanging the whole machine — and only the first sound would play before things
broke. Root cause was threading: all audio and overlay work was running on the
global keyboard/mouse hook thread, and the players were being destroyed and
then reused.

## Root cause

- The players (`WaveOutEvent`) were `Init`'d on the EventHook callback thread,
  which has no WPF `SynchronizationContext`. NAudio therefore raised
  `PlaybackStopped` on a background thread, where the handler did a **blocking**
  `Dispatcher.Invoke`. Combined with `stop()` calling `Dispose()` while audio
  was playing, this could deadlock (Dispose waiting on the playback thread,
  the playback thread waiting on the UI thread) — an intermittent, timing-
  dependent freeze. A leaked/never-released device then dragged the whole
  system down.
- Because `stop()` **disposed** the reused `WaveOutEvent`, the second playback
  hit a disposed device and threw `ObjectDisposedException`.

## Changes

- **EventListener**: hook callbacks now only do the cheap key match and marshal
  the state change to the UI thread via `Dispatcher.BeginInvoke`. This runs all
  audio/overlay work on the UI thread (so NAudio marshals `PlaybackStopped`
  back safely) and serializes the keyboard + mouse watchers so overlay-state
  transitions can't interleave.
- **MicPlayer / SpeakerPlayer**: `stop()` calls `Stop()` instead of `Dispose()`
  so the device is reused; the `MediaFoundationReader` is disposed in
  `PlaybackStopped` (fixes a per-playback resource leak).
- **EventListener**: overlay state resets to Hidden when a clip finishes on its
  own, so the state machine no longer desyncs after a sound ends naturally.

## Other stability fixes included

- **Settings file**: stored one value per line instead of one comma-joined
  line, so a comma in the meme folder path can no longer corrupt it (old
  single-line files are migrated automatically on read).
- **Volume parsing**: uses `InvariantCulture`, so the app no longer crashes on
  Start on machines whose locale uses a comma as the decimal separator.
- **Meme filtering**: extensions are matched exactly (a file with no extension
  used to slip through and crash the player) and the list is cleared before
  filtering to avoid duplicates.

## Testing

Built against .NET Framework 4.7.2 and ran locally: plays multiple sounds in a
row, stop/scroll work, and sounds ending on their own leave the overlay in a
clean state.